### PR TITLE
Fix sometimes receiving items on the titlescreen

### DIFF
--- a/TWWClient.py
+++ b/TWWClient.py
@@ -143,7 +143,7 @@ def write_short(console_address: int, value: int) -> None:
 
 
 def read_string(console_address: int, strlen: int) -> str:
-    return dolphin_memory_engine.read_bytes(console_address, strlen).decode().strip("\0")
+    return dolphin_memory_engine.read_bytes(console_address, strlen).split(b"\0", 1)[0].decode()
 
 
 def _give_death(ctx: TWWContext):


### PR DESCRIPTION
The `read_string()` function was stripping trailing null characters, however, when setting the stage name, TWW only writes bytes up to and including the null character, so any previously written bytes within the 8 bytes of storage would remain.

E.g. going to Ice Ring Isle Cave will set the stage name to `b"MiniHyo\0"`, writing over all 8 bytes. Going directly from Ice Ring Isle Cave to the title screen will set the stage name to `b"sea_T\0"`, but because this is only 6 bytes, the last two bytes will remain unchanged and the full 8 bytes will be `b"sea_T\0o\0"`, so stripping null characters would return the incorrect bytestring `b"sea_T\0o"` which the AP Client would not consider to be the title screen in `check_ingame()`.

`read_string()` has been changed to split the bytes by the first occurrence of a null character. Everything before the first null character will be the string. If there is no null character present, then the string will be considered all the bytes that were read.