### PR TITLE
Add support for stage and entrance tracking in the PopTracker package

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -595,7 +595,7 @@ class TWWWorld(World):
         return res
 
     def fill_slot_data(self):
-        return {
+        slot_data = {
             "progression_dungeons": self.options.progression_dungeons.value,
             "progression_tingle_chests": self.options.progression_tingle_chests.value,
             "progression_dungeon_secrets": self.options.progression_dungeon_secrets.value,
@@ -660,3 +660,9 @@ class TWWWorld(World):
             "remove_music": self.options.remove_music.value,
             "death_link": self.options.death_link.value,
         }
+        # Add entrances to slot_data. This is the same data that is written to the .aptww file.
+        entrances = {entrance.parent_region.name: entrance.connected_region.name
+                     for entrance in self.multiworld.get_entrances(self.player)
+                     if entrance.parent_region.name in ALL_ENTRANCES}
+        slot_data["entrances"] = entrances
+        return slot_data


### PR DESCRIPTION
This PR depends on https://github.com/tanjo3/tww_apworld/pull/3 so that the stage names sent to the tracker will be correct.

Sending a Bounce message to the server tells the server to send a Bounced message with the same data to all clients connected to the specified slots with the specified tags, in this case, to the current player's connected tracker(s). Each time the player's current stage name changes (while they are considered in-game), it is sent to connected tracker(s), which can then change which map is currently being displayed in the tracker to match.

To be able to automatically fill in entrance->exit pairs in entrance rando, the tracker needs to know what exit each entrance leads to, so that when it receives a Bounced message containing the player's current stage name, it can look up which entrance the player must have entered to get to that stage, and can then automatically assign the entrance->exit pair.

---

Tested locally with the tracker update I'm working on and it worked great.

The only issue is that the Cliff Plateau Isles Inner Exit is part of the "sea" stage, so cannot be filled in automatically in entrance rando, but everything else works so far.