### PR TITLE
NumRequiredBosses Tooltip

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -331,8 +331,8 @@ class RequiredBosses(Toggle):
 class NumRequiredBosses(Range):
     """Select the number of randomly-chosen bosses that are required in Required Bosses Mode.
 
-    The door to Puppet Ganon will not unlock until you've defeated all of these bosses. Nothing in dungeons for other
-    bosses will ever be required."""
+    The door to Puppet Ganon will not unlock until you've defeated all of these bosses. Dungeons that contain bosses
+    that are not required will contain filler items only and will never contain progression items."""
 
     display_name = "Number of Required Bosses"
     range_start = 1


### PR DESCRIPTION
The existing tooltip leads players to believe that there is either nothing in these locations at all, or that the items present have no value.  However, numerous other worlds either misuse the filler tag, or dump helpful but not critical items into it.  As a result, many players will claim they have nothing to do in their world when some of these locations will stay have meaningful value to multiworld participants.  This change clarifies the filler class and emphasizes the lack of progression, to at least minimize the number of people who might believe the locations simply do not exist.