### PR TITLE
Update The Wind Waker.yaml

### DIFF
--- a/The Wind Waker.yaml
+++ b/The Wind Waker.yaml
@@ -466,6 +466,14 @@ The Wind Waker:
 
   start_inventory_from_pool:
     # Start with these items and don't place them in the world.
-    # 
+    #
     # The game decides what the replacement items will be.
-    {}
+    {
+      "Wind Waker": 1,
+      "Wind's Requiem": 1,
+      "Ballad of Gales": 1,
+      "Song of Passing": 1,
+      "Progressive Magic Meter": 1,
+      "Progressive Shield": 1,
+      "Telescope": 1,
+    }


### PR DESCRIPTION
Sane defaults for starting items. Notably wooferzfg's tracker assumes magic, one shield, wind's requiem and song of passing, so it's more convenient for people who want to use it (if you don't tinker with your setting string and just go on the website).
It's also easier to remove those lines if they're already here than to add them.